### PR TITLE
Fix ASCII name check bug

### DIFF
--- a/src/Guide/Modules/WaitingRoom.cs
+++ b/src/Guide/Modules/WaitingRoom.cs
@@ -27,7 +27,9 @@ namespace Guide.Modules
                 return;
             }
 
-            if(!IsAsciiPrintable(user.Username[0]))
+
+            var visibleName = user.Nickname ?? user.Username;
+            if(!IsAsciiPrintable(visibleName[0]))
             {
                 await WarnNonAsciiName();
                 return;


### PR DESCRIPTION
We used to only check the name (that only Nitro users can change), changing a nickname should be valid now.

This should not have taken us this long to fix.