### PR TITLE
Create voice chat role toggle

### DIFF
--- a/src/Guide/Constants.cs
+++ b/src/Guide/Constants.cs
@@ -15,12 +15,16 @@ namespace Guide
         public const ulong GeneralId = 488989707900813313;
         public const ulong MemberRoleId = 470188590538948608;
         public const ulong HelperRoleId = 529659044277780480;
+        public const ulong VoiceChatRoleId = 0;
+        public const ulong VoiceChannelId = 535922633225535489;
 #else
         public const ulong TutorialGuildId = 377879473158356992;
         public const ulong WaitingRoomId = 411864218548043785;
         public const ulong GeneralId = 377879473644765185;
         public const ulong MemberRoleId = 411865173318696961;
         public const ulong HelperRoleId = 480033369812500491;
+        public const ulong VoiceChatRoleId = 0;
+        public const ulong VoiceChannelId = 535922633225535489;
 #endif
 
         public const string PKWelcomeTitle = "WELCOME_EMBED_TITLE";

--- a/src/Guide/Guide.csproj
+++ b/src/Guide/Guide.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Guide/InversionOfControl.cs
+++ b/src/Guide/InversionOfControl.cs
@@ -43,6 +43,7 @@ namespace Guide
                 c.ForSingletonOf<IJsonStorage>().UseIfNone<JsonStorage>();
                 c.ForSingletonOf<ILanguage>().UseIfNone<JsonLanguage>();
                 c.ForSingletonOf<WelcomeMessageService>().UseIfNone<WelcomeMessageService>();
+                c.ForSingletonOf<VoiceChatService>().UseIfNone<VoiceChatService>();
                 c.ForSingletonOf<DiscordSocketClient>().UseIfNone(DiscordSocketClientFactory.GetDefault());
             });
         }

--- a/src/Guide/Services/ServicesBootstrapper.cs
+++ b/src/Guide/Services/ServicesBootstrapper.cs
@@ -4,7 +4,8 @@ namespace Guide.Services
     {
         public ServicesBootstrapper(
             WelcomeMessageService welcomeMessageService,
-            UsernameService usernameService
+            UsernameService usernameService,
+            VoiceChatService voiceChatService
             )
         {
             // initialize a service if needed...

--- a/src/Guide/Services/VoiceChatService.cs
+++ b/src/Guide/Services/VoiceChatService.cs
@@ -1,0 +1,49 @@
+﻿using Discord.WebSocket;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Guide.Services
+{
+    public class VoiceChatService
+    {
+        private readonly DiscordSocketClient _client;
+        public VoiceChatService(DiscordSocketClient client)
+        {
+            _client = client;
+
+            _client.UserVoiceStateUpdated += OnUserVoiceStateUpdated;
+        }
+
+        private async Task OnUserVoiceStateUpdated(SocketUser user, SocketVoiceState previous, SocketVoiceState current)
+        {
+            var guildUser = (user as SocketGuildUser);
+            var voiceChannel = current.VoiceChannel ?? previous.VoiceChannel;
+
+            if (voiceChannel.Guild.Id != Constants.TutorialGuildId)
+                return;
+
+            var role = voiceChannel.Guild.GetRole(Constants.VoiceChatRoleId);
+
+            if (role == null)
+                return;
+
+            bool hasRole = guildUser.Roles.Any(x => x.Id == Constants.VoiceChatRoleId);
+
+            if (current.VoiceChannel?.Id == Constants.VoiceChannelId)
+            {
+                if (!hasRole)
+                {
+                    await guildUser.AddRoleAsync(role);
+                }
+            }
+            else if (previous.VoiceChannel?.Id == Constants.VoiceChannelId)
+            {
+                if (hasRole)
+                {
+                    await guildUser.RemoveRoleAsync(role);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes
- ~~Updated .NET Core App to 3.0 (Required)~~ (I'll manually revert it and see if that would still be fine)
- Create class `VoiceChatService`
- Added properties `VoiceChatRoleId` and `VoiceChannelId` in Constants
- Modify method `InitializeContainer()` in `InversionOfControl` to include `VoiceChatService`
- Modify constructor for `ServicesBootstrapper` to include `VoiceChatService`

## Summary
This felt like a sloppy fix, but it does get the job done. The only requirements is that the ID of the role that you want to correlate to the channel is specified in `Constants.VoiceChatRoleId`.